### PR TITLE
#5 Add captcha for all ajax request

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ return [
 
 - This prebuilt JS also add captcha to all ajax requests.
 
-- If you don't want to add the reCAPTCHA to any ajax request in frontend then add `disabledisableCaptcha: true` attribute to ajax options and it will exclude that request from adding the reCAPTCHA. You can use this feature with `allowed_methods` config to completly exclude any ajax request from reCAPTCHA validation.
+- If you don't want to add the reCAPTCHA to any ajax request in frontend then add `disableCaptcha: true` attribute to ajax options and it will exclude that request from adding the reCAPTCHA. You can use this feature with `allowed_methods` config to completly exclude any ajax request from reCAPTCHA validation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,18 @@ return [
 
 - If you don't want to add the reCAPTCHA to any form in frontend then add `data-no-captcha` attribute to form tag and it will exclude that form from rendering the reCAPTCHA. You can use this feature with `allowed_methods` config to completly exclude any form from reCAPTCHA validation.
 
+---
+
+### Ajax Config
+
+- This prebuilt JS also add captcha to all ajax requests.
+
+- If you don't want to add the reCAPTCHA to any ajax request in frontend then add `disabledisableCaptcha: true` attribute to ajax options and it will exclude that request from adding the reCAPTCHA. You can use this feature with `allowed_methods` config to completly exclude any ajax request from reCAPTCHA validation.
+
+---
+
+### Manual reCAPTCHA
+
 - You can also add google reCAPTCHA to any form manually if needed:
 
 1. Create a div with data-size="invisible".

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ return [
 
 - For core PHP project replace env() function with static values if you haven't downloaded env package, else it will throw function error.
 
-- If you don't want to add the reCAPTCHA to any form in frontend then add `data-no-captcha` attribute to form tag and it will exclude that form from rendering the reCAPTCHA. You can use this feature with `allowed_methods` config to completly exclude any form from reCAPTCHA validation.
+- If you don't want to add the reCAPTCHA to any form in frontend then add `data-no-captcha` attribute to form tag and it will exclude that form from rendering the reCAPTCHA. You can use this feature with `allowed_methods` config to completely exclude any form from reCAPTCHA validation.
 
 ---
 
@@ -199,7 +199,7 @@ return [
 
 - This prebuilt JS also add captcha to all ajax requests.
 
-- If you don't want to add the reCAPTCHA to any ajax request in frontend then add `disableCaptcha: true` attribute to ajax options and it will exclude that request from adding the reCAPTCHA. You can use this feature with `allowed_methods` config to completly exclude any ajax request from reCAPTCHA validation.
+- If you don't want to add the reCAPTCHA to any ajax request in frontend then add `disableCaptcha: true` attribute to ajax options and it will exclude that request from adding the reCAPTCHA. You can use this feature with `allowed_methods` config to completely exclude any ajax request from reCAPTCHA validation.
 
 ---
 

--- a/resources/js/auto-recaptcha.js
+++ b/resources/js/auto-recaptcha.js
@@ -1,5 +1,21 @@
-var onloadCallback = function() {
-    let forms = document.querySelectorAll('form:not([data-no-captcha]):not([method="get"])');
+function getRecaptchaConfig() {
+    const el = document.getElementById('recaptcha-config');
+    if (!el) return {};
+    try {
+        return JSON.parse(el.textContent);
+    } catch (e) {
+        console.error('Invalid reCAPTCHA config');
+        return {};
+    }
+}
+
+var onloadCallback = function () {
+    const { sitekey, other_config } = getRecaptchaConfig();
+    const allowedMethodsArr = other_config.allowed_methods || ['POST', 'PUT', 'DELETE'];
+    const allowedMethods = allowedMethodsArr.map(m => m.toLowerCase());
+
+    const forms = Array.from(document.querySelectorAll('form:not([data-no-captcha])'))
+    .filter(form => allowedMethods.includes(form.method.toLowerCase()));
 
     forms.forEach((form, index) => {
         // create a container div for captcha
@@ -10,15 +26,15 @@ var onloadCallback = function() {
 
         // prevent normal submit
         form.addEventListener('submit', function (e) {
-        e.preventDefault();
-        grecaptcha.execute(widgetIds[index]);
+            e.preventDefault();
+            grecaptcha.execute(widgetIds[index]);
         });
 
         // render captcha in invisible mode
         let widgetId = grecaptcha.render(captchaId, {
-            'sitekey' : window.RECAPTCHA_SITEKEY,
-            'size' : 'invisible',
-            'callback' : function(token) {
+            'sitekey': sitekey,
+            'size': 'invisible',
+            'callback': function (token) {
                 // on success, submit the form
                 form.submit();
             }
@@ -30,4 +46,53 @@ var onloadCallback = function() {
         }
         window.widgetIds[index] = widgetId;
     });
+
+    // Add invisible captcha for ajax requests
+    const ajaxDiv = document.createElement('div');
+    ajaxDiv.id = 'captcha-ajax';
+    ajaxDiv.style.display = 'none';
+    document.body.appendChild(ajaxDiv);
+
+    const originalAjax = $.ajax;
+    let ajaxCaptchaWidgetId;
+
+    // Render one invisible captcha for ajax requests
+    ajaxCaptchaWidgetId = grecaptcha.render('captcha-ajax', {
+        'sitekey': sitekey,
+        'size': 'invisible'
+    });
+
+    // Override $.ajax globally
+    $.ajax = function (options) {
+        const isPostOrPut = options.type && allowedMethods.includes(options.type.toLowerCase());
+        const isRecaptchaUrl = options.url && options.url.includes('google.com/recaptcha/api');
+        const disableCaptcha = options.disableCaptcha === true;
+
+        if (isPostOrPut && !isRecaptchaUrl && !disableCaptcha && ajaxCaptchaWidgetId !== undefined) {
+            return new Promise(function (resolve, reject) {
+                grecaptcha.execute(ajaxCaptchaWidgetId).then(function (token) {
+                    // Add token to request
+                    if (typeof options.data === 'string') {
+                        options.data += (options.data ? '&' : '') + `g-recaptcha-response=${encodeURIComponent(token)}`;
+                    } else if (options.data instanceof FormData) {
+                        options.data.append('g-recaptcha-response', token);
+                    } else if (typeof options.data === 'object') {
+                        options.data['g-recaptcha-response'] = token;
+                    } else {
+                        options.data = { 'g-recaptcha-response': token };
+                    }
+
+                    // Send request
+                    const jqXHR = originalAjax.call($, options);
+
+                    // Reset after completion
+                    jqXHR.always(() => grecaptcha.reset(ajaxCaptchaWidgetId));
+
+                    jqXHR.then(resolve).catch(reject);
+                });
+            });
+        } else {
+            return originalAjax.call($, options);
+        }
+    };
 };

--- a/src/AutoGoogleRecaptcha.php
+++ b/src/AutoGoogleRecaptcha.php
@@ -87,21 +87,27 @@ class AutoGoogleRecaptcha
         $params['onload'] = 'onloadCallback';
         $lang ? $params['hl'] = $lang : null;
 
-        $scriptGoogle = '<script src="'. static::CLIENT_API . '?'. http_build_query($params) .'"></script>';
-        $siteKeyGlobal = '<script> window.RECAPTCHA_SITEKEY = "'. $this->sitekey .'"; </script>';
+        $scriptGoogle = '<script src="'. static::CLIENT_API . '?'. http_build_query($params) .'" async defer></script>';
+        // Inject config in a JSON <script> tag with id
+        $scriptConfig = '<script id="recaptcha-config" type="application/json">'
+            . json_encode([
+                'sitekey' => $this->sitekey,
+                'other_config' => $this->options,
+            ])
+            . '</script>';
 
         // Detect Laravel
         $isLaravel = function_exists('app') && class_exists(\Illuminate\Support\Facades\App::class);
 
         if ($isLaravel) {
             // Use published path in Laravel
-            $scriptPackage = '<script src="' . asset('vendor/auto-google-recaptcha/auto-recaptcha.js') . '"></script>';
+            $scriptPackage = '<script src="' . asset('vendor/auto-google-recaptcha/auto-recaptcha.js') . '" async defer></script>';
         } else {
             // For plain PHP, serve directly (relative path from vendor)
-            $scriptPackage = '<script src="'. static::LOCAL_SCRIPT_PATH .'"></script>';
+            $scriptPackage = '<script src="'. static::LOCAL_SCRIPT_PATH .'" async defer></script>';
         }
 
-        return $scriptGoogle . "\n" . $siteKeyGlobal . "\n" . $scriptPackage;
+        return $scriptGoogle . "\n" . $scriptConfig . "\n" . $scriptPackage;
     }
 
     /**


### PR DESCRIPTION
## Description

- Added captcha support for all Ajax requests.
- User can disable for a specific Ajax request by adding `disableCaptcha: true` in the ajax option.
- Updated README accordingly.
